### PR TITLE
Added validation to content type id. Issue #18

### DIFF
--- a/N1990.Episerver.Cms.Audit/modules/_protected/CmsAudit/Views/Shared/_layout.cshtml
+++ b/N1990.Episerver.Cms.Audit/modules/_protected/CmsAudit/Views/Shared/_layout.cshtml
@@ -203,28 +203,30 @@
     }
     function getContentTypeAudit(contentTypeRow) {
         var $contentTypeRow = $(contentTypeRow);
-        var contentTypeId = $contentTypeRow.data('contenttypeid');
-        var url = $('#cms-content-types').data('type') == 'page'
-            ? 'pagetypes/pagetypeaudit'
-            : ($('#cms-content-types').data('type') == 'block' ? 'blocktypes/blocktypeaudit' : '');
-        if (url !== '') {
-            $.ajax({
-                url: url,
-                data: {
-                    contentTypeId: contentTypeId
-                },
-                error: function (xhr, status, error) {
-                    $contentTypeRow.find('td.usages').text("Unknown. Error encountered.");
-                }
-            }).done(function (response) {
-                var rowNumber = $contentTypeRow.find('.number').text();
-                var $response = $(response);
-                $response.find('.number').text(rowNumber);
-                $contentTypeRow.replaceWith($response);
-                var progressPercentage = 100 - ($('#cms-content-types tr .loader').length * 100 / $contentTypes.length);
-                updateProgressBar('#cms-content-types .progress', progressPercentage);
-            });
-        }
+		var contentTypeId = $contentTypeRow.data('contenttypeid');
+		if (contentTypeId != undefined) {
+			var url = $('#cms-content-types').data('type') == 'page'
+				? 'pagetypes/pagetypeaudit'
+				: ($('#cms-content-types').data('type') == 'block' ? 'blocktypes/blocktypeaudit' : '');
+			if (url !== '') {
+				$.ajax({
+					url: url,
+					data: {
+						contentTypeId: contentTypeId
+					},
+					error: function (xhr, status, error) {
+						$contentTypeRow.find('td.usages').text("Unknown. Error encountered.");
+					}
+				}).done(function (response) {
+					var rowNumber = $contentTypeRow.find('.number').text();
+					var $response = $(response);
+					$response.find('.number').text(rowNumber);
+					$contentTypeRow.replaceWith($response);
+					var progressPercentage = 100 - ($('#cms-content-types tr .loader').length * 100 / $contentTypes.length);
+					updateProgressBar('#cms-content-types .progress', progressPercentage);
+				});
+			}
+		}
     }
 </script>
 </body>


### PR DESCRIPTION
In all three tabs (Page Types, Block Types and Visitor Group) first API call is made with a content type id "undefined". Subsequent calls are made and rendered as expected. But when a solution is set up with custom error page, then the first call with undefined will result in "500 error page".

To overcome this, validated the content type id.